### PR TITLE
Add extra server and client options

### DIFF
--- a/conf/openvpn-client-config.tpl
+++ b/conf/openvpn-client-config.tpl
@@ -16,3 +16,5 @@ cert {{ .Cert }}
 key {{ .Key }}
 
 comp-lzo
+
+{{ .ExtraClientOptions }}

--- a/conf/openvpn-server-config.tpl
+++ b/conf/openvpn-server-config.tpl
@@ -17,8 +17,8 @@ dh {{ .Dh }}
 server 10.8.0.0 255.255.255.0
 ifconfig-pool-persist {{ .IfconfigPoolPersist }}
 push "route 10.8.0.0 255.255.255.0"
-push "dhcp-option DNS 8.8.8.8"
-push "dhcp-option DNS 8.8.4.4"
+push "dhcp-option DNS {{ .DNSServerOne }}"
+push "dhcp-option DNS {{ .DNSServerTwo }}"
 
 keepalive {{ .Keepalive }}
 
@@ -32,3 +32,5 @@ log         openvpn.log
 verb 3
 
 mute 10
+
+{{ .ExtraServerOptions }}

--- a/controllers/certificates.go
+++ b/controllers/certificates.go
@@ -148,6 +148,7 @@ func saveClientConfig(name string) (string, error) {
 	cfg.Auth = serverConfig.Auth
 	cfg.Cipher = serverConfig.Cipher
 	cfg.Keysize = serverConfig.Keysize
+	cfg.ExtraClientOptions = serverConfig.ExtraClientOptions
 
 	destPath := models.GlobalCfg.OVConfigPath + "keys/" + name + ".conf"
 	if err := config.SaveToFile("conf/openvpn-client-config.tpl",

--- a/models/models.go
+++ b/models/models.go
@@ -98,6 +98,8 @@ func createDefaultOVConfig() {
 		Config: config.Config{
 			Port:                1194,
 			Proto:               "udp",
+			DNSServerOne:        "8.8.8.8",
+			DNSServerTwo:        "8.8.4.4",
 			Cipher:              "AES-256-CBC",
 			Keysize:             256,
 			Auth:                "SHA256",
@@ -110,6 +112,8 @@ func createDefaultOVConfig() {
 			Ca:                  "keys/ca.crt",
 			Cert:                "keys/server.crt",
 			Key:                 "keys/server.key",
+			ExtraServerOptions:  "",
+			ExtraClientOptions:  "",
 		},
 	}
 	o := orm.NewOrm()

--- a/views/ovconfig.html
+++ b/views/ovconfig.html
@@ -35,6 +35,20 @@
       </div>
 
       <div class="form-group">
+        <label for="name">DNSServerOne</label>
+        <input type="text" class="form-control" name="DNSServerOne" id="DNSServerOne" placeholder="Enter the first DNS server"
+          value="{{ .Settings.DNSServerOne }}">
+        <span class="help-block">Enter the first DNS server</span>
+      </div>
+
+      <div class="form-group">
+        <label for="name">DNSServerTwo</label>
+        <input type="text" class="form-control" name="DNSServerTwo" id="DNSServerTwo" placeholder="Enter the second DNS server"
+          value="{{ .Settings.DNSServerTwo }}">
+        <span class="help-block">Enter the second DNS server</span>
+      </div>
+
+      <div class="form-group">
         <label for="name">CA cert</label>
         <input type="text" class="form-control" name="Ca" id="Ca" placeholder="Enter CA certificate path"
           value="{{ .Settings.Ca }}">
@@ -121,6 +135,20 @@
           value="{{ .Settings.MaxClients }}">
         <span id="helpBlock" class="help-block">The maximum number of concurrently connected
             clients we want to allow.</span>
+      </div>
+
+      <div class="form-group">
+        <label for="name">ExtraServerOptions</label>
+        <textarea type="text" class="form-control" name="ExtraServerOptions" 
+          id="ExtraServerOptions">{{ .Settings.ExtraServerOptions }}</textarea>
+        <span id="helpBlock" class="help-block">Extra server options to add to the config.</span>
+      </div>
+
+      <div class="form-group">
+        <label for="name">ExtraClientOptions</label>
+        <textarea type="text" class="form-control" name="ExtraClientOptions" 
+          id="ExtraClientOptions">{{ .Settings.ExtraClientOptions }}</textarea>
+        <span id="helpBlock" class="help-block">Extra client options to add to the generated client configs.</span>
       </div>
 
       <div class="form-group">


### PR DESCRIPTION
In this PR we add the ability to specify DNS servers and to add extra config options to the server and client configs.

https://github.com/adamwalach/go-openvpn/pull/4 must be merged prior to merging this.